### PR TITLE
Update download URL from HRConvert2 v2.4 to v2.6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ chmod -R 0755 /home/converter && \
 chown -R www-data /home/converter && \
 chgrp -R www-data /home/converter
 
-RUN wget https://github.com/zelon88/HRConvert2/archive/v2.4.zip -O /tmp/2.4.zip && \
-unzip /tmp/2.4.zip -d /tmp/ && \
-mv /tmp/HRConvert2-2.4/* /var/www/html/HRProprietary/HRConvert2 && \
+RUN wget https://github.com/zelon88/HRConvert2/archive/v2.6.zip -O /tmp/2.6.zip && \
+unzip /tmp/2.6.zip -d /tmp/ && \
+mv /tmp/HRConvert2-2.6/* /var/www/html/HRProprietary/HRConvert2 && \
 rm -rf /var/www/html/index.html && \
 
 COPY index.html /var/www/html/index.html


### PR DESCRIPTION
Updated wget command to get the latest v2.6 release of HRConvert2 instead of v2.4.