### PR TITLE
Tidy Dockerfile, Fix rar operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM ubuntu:20.04
 
+ARG VERSION=2.9.2
+
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 EXPOSE 80
 
-RUN add-apt-repository multiverse && \
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common --no-install-recommends && \
+    add-apt-repository multiverse && \
     apt-get update && \
     apt-get upgrade -yy && \
     apt-get install -y apache2 default-jre php php-mysql \ 
                        php-all-dev php-zip php-gd php-curl clamav libreoffice-common \ 
-                       unoconv p7zip-full imagemagick unrar-free ffmpeg tesseract-ocr \ 
+                       unoconv p7zip-full imagemagick ffmpeg tesseract-ocr \ 
                        meshlab dia pandoc poppler-utils zip unzip wget rar unrar --no-install-recommends && \
     apt-get clean && \ 
     rm -rf /var/lib/apt/lists/*
@@ -26,19 +30,19 @@ RUN mkdir -p $APACHE_RUN_DIR && \
     mkdir -p $APACHE_LOG_DIR
 
 
-COPY uploads.ini /etc/php/7.2/apache2/conf.d/uploads.ini
+COPY uploads.ini /etc/php/7.4/apache2/conf.d/uploads.ini
 CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
 
 RUN mkdir /var/www/html/HRProprietary && \
-mkdir /var/www/html/HRProprietary/HRConvert2 && \
-mkdir /home/converter && \
-chmod -R 0755 /home/converter && \
-chown -R www-data /home/converter && \
-chgrp -R www-data /home/converter
+    mkdir /var/www/html/HRProprietary/HRConvert2 && \
+    mkdir /home/converter && \
+    chmod -R 0755 /home/converter && \
+    chown -R www-data /home/converter && \
+    chgrp -R www-data /home/converter
 
-RUN wget https://github.com/zelon88/HRConvert2/archive/v2.9.2.zip -O /tmp/2.9.2.zip && \
-    unzip /tmp/2.9.2.zip -d /tmp/ && \
-    mv /tmp/HRConvert2-2.9.2/* /var/www/html/HRProprietary/HRConvert2 && \
+RUN wget https://github.com/zelon88/HRConvert2/archive/v${VERSION}.zip -O /tmp/HRConvert2.zip && \
+    unzip /tmp/HRConvert2.zip -d /tmp/ && \
+    mv /tmp/HRConvert2-${VERSION}/* /var/www/html/HRProprietary/HRConvert2 && \
     rm -rf /var/www/html/index.html
 
 COPY index.html /var/www/html/index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ FROM ubuntu:20.04
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 EXPOSE 80
 
-RUN apt-get update && \
-apt-get upgrade -yy && \
-apt-get install -y apache2 default-jre php php-mysql \ 
-php-all-dev php-zip php-gd php-curl clamav libreoffice-common \ 
-unoconv p7zip-full imagemagick unrar-free ffmpeg tesseract-ocr \ 
-meshlab dia pandoc poppler-utils zip unzip wget --no-install-recommends && \
-apt-get clean && \ 
-rm -rf /var/lib/apt/lists/*
+RUN add-apt-repository multiverse && \
+    apt-get update && \
+    apt-get upgrade -yy && \
+    apt-get install -y apache2 default-jre php php-mysql \ 
+                       php-all-dev php-zip php-gd php-curl clamav libreoffice-common \ 
+                       unoconv p7zip-full imagemagick unrar-free ffmpeg tesseract-ocr \ 
+                       meshlab dia pandoc poppler-utils zip unzip wget rar unrar --no-install-recommends && \
+    apt-get clean && \ 
+    rm -rf /var/lib/apt/lists/*
 
 ENV APACHE_RUN_USER  www-data
 ENV APACHE_RUN_GROUP www-data
@@ -21,8 +22,8 @@ ENV APACHE_LOCK_DIR  /var/lock/apache2
 ENV APACHE_LOG_DIR   /var/log/apache2
 
 RUN mkdir -p $APACHE_RUN_DIR && \
-mkdir -p $APACHE_LOCK_DIR && \
-mkdir -p $APACHE_LOG_DIR
+    mkdir -p $APACHE_LOCK_DIR && \
+    mkdir -p $APACHE_LOG_DIR
 
 
 COPY uploads.ini /etc/php/7.2/apache2/conf.d/uploads.ini
@@ -36,20 +37,20 @@ chown -R www-data /home/converter && \
 chgrp -R www-data /home/converter
 
 RUN wget https://github.com/zelon88/HRConvert2/archive/v2.9.2.zip -O /tmp/2.9.2.zip && \
-unzip /tmp/2.9.2.zip -d /tmp/ && \
-mv /tmp/HRConvert2-2.9.2/* /var/www/html/HRProprietary/HRConvert2 && \
-rm -rf /var/www/html/index.html
+    unzip /tmp/2.9.2.zip -d /tmp/ && \
+    mv /tmp/HRConvert2-2.9.2/* /var/www/html/HRProprietary/HRConvert2 && \
+    rm -rf /var/www/html/index.html
 
 COPY index.html /var/www/html/index.html
 
 RUN chmod -R 0755 /var/www/html && \
-chown -R www-data /var/www/html && \
-chgrp -R www-data /var/www/html && \
-rm -rf /var/www/html/HRProprietary/HRConvert2/config.php
+    chown -R www-data /var/www/html && \
+    chgrp -R www-data /var/www/html && \
+    rm -rf /var/www/html/HRProprietary/HRConvert2/config.php
 
 COPY config.php /var/www/html/HRProprietary/HRConvert2/config.php
 
 RUN wget https://raw.githubusercontent.com/zelon88/HRConvert2/master/rc.local -O /etc/rc.local && \
-chmod +x /etc/rc.local
-RUN /usr/bin/soffice --headless --accept="socket,host=127.0.0.1,port=$soffice_port;urp;" --nofirststartwizard &
+    chmod +x /etc/rc.local
 
+RUN /usr/bin/soffice --headless --accept="socket,host=127.0.0.1,port=$soffice_port;urp;" --nofirststartwizard &


### PR DESCRIPTION
Fixes #7 .  
* Added the multiverse repository (which requires `software-properties-common`).  The official `rar` and `unrar` packages live here.
* Removed unrar-free, since we now install unrar

Also tidied up a couple of other things:
* Added a Build Arg for the HRconvert version, so it'll be easier to update going forwards.
* As part of this, Ive tweaked the download and deploy of the HRConvert application (changed the filename of the /tmp file)
* Indented multi-line RUN commands.  I think it's easier to read this way
* Updated the PHP version to 7.4 when copying `uploads.ini`

Tested by:
* uploading a rar and converting to zip- all good
* Vice versa (uploading a zip and downloading a rar)

Note that Im not 100% sure about the PHP version change - the Docker logs imply we're installing PHP 7.4 but I haven't explicitly checked any further than that