### PR TITLE
support latest upstream zelon88/HRConvert2 code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:20.04
-
-ARG VERSION=2.9.2
+FROM ubuntu:22.04
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 EXPOSE 80
@@ -10,7 +8,7 @@ RUN apt-get update -y && \
     add-apt-repository multiverse && \
     apt-get update && \
     apt-get upgrade -yy && \
-    apt-get install -y apache2 default-jre php php-mysql \ 
+    apt-get install -y git apache2 default-jre php php-mysql \ 
                        php-all-dev php-zip php-gd php-curl clamav libreoffice-common \ 
                        unoconv p7zip-full imagemagick ffmpeg tesseract-ocr \ 
                        meshlab dia pandoc poppler-utils zip unzip wget rar unrar --no-install-recommends && \
@@ -30,31 +28,27 @@ RUN mkdir -p $APACHE_RUN_DIR && \
     mkdir -p $APACHE_LOG_DIR
 
 
-COPY uploads.ini /etc/php/7.4/apache2/conf.d/uploads.ini
+COPY uploads.ini /etc/php/8.1/apache2/conf.d/uploads.ini
 CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
 
 RUN mkdir /var/www/html/HRProprietary && \
-    mkdir /var/www/html/HRProprietary/HRConvert2 && \
     mkdir /home/converter && \
     chmod -R 0755 /home/converter && \
     chown -R www-data /home/converter && \
     chgrp -R www-data /home/converter
 
-RUN wget https://github.com/zelon88/HRConvert2/archive/v${VERSION}.zip -O /tmp/HRConvert2.zip && \
-    unzip /tmp/HRConvert2.zip -d /tmp/ && \
-    mv /tmp/HRConvert2-${VERSION}/* /var/www/html/HRProprietary/HRConvert2 && \
-    rm -rf /var/www/html/index.html
+RUN git clone https://github.com/zelon88/HRConvert2.git /var/www/html/HRProprietary/HRConvert2 && \
+    rm -rf /var/www/html/HRProprietary/HRConvert2/.git
 
 COPY index.html /var/www/html/index.html
 
 RUN chmod -R 0755 /var/www/html && \
     chown -R www-data /var/www/html && \
-    chgrp -R www-data /var/www/html && \
-    rm -rf /var/www/html/HRProprietary/HRConvert2/config.php
+    chgrp -R www-data /var/www/html
 
 COPY config.php /var/www/html/HRProprietary/HRConvert2/config.php
 
-RUN wget https://raw.githubusercontent.com/zelon88/HRConvert2/master/rc.local -O /etc/rc.local && \
+RUN mv /var/www/html/HRProprietary/HRConvert2/rc.local /etc/rc.local && \
     chmod +x /etc/rc.local
 
 RUN /usr/bin/soffice --headless --accept="socket,host=127.0.0.1,port=$soffice_port;urp;" --nofirststartwizard &

--- a/config.php
+++ b/config.php
@@ -18,6 +18,9 @@ $VirusScan = FALSE;
 $ApplicationName = 'HRConvert2';
 $ApplicationTitle = 'Convert Anything!';
 
+$SupportedGuis = array('Default');
+$DefaultGui = 'Default';
+$AllowUserSelectableGui = FALSE;
 $SupportedLanguages = array('en', 'fr', 'es', 'zh', 'hi', 'ar', 'ru', 'uk', 'bn', 'de', 'ko', 'it', 'pt');
 //Default language
 $DefaultLanguage = 'en';
@@ -25,6 +28,7 @@ $AllowUserSelectableLanguage = TRUE;
 
 //Set to FALSE to disable users creating share links
 $AllowUserShare = TRUE;
+$SupportedConversionTypes = array('Document', 'Image', 'Model', 'Drawing', 'Video', 'Subtitle', 'Audio', 'Archive', 'Stream', 'OCR');
 
 //Button colour - RED,GREEN,BLUE,GREY
 $ButtonStyle = 'BLUE';

--- a/index.html
+++ b/index.html
@@ -1,1 +1,21 @@
-<html><head><meta http-equiv="refresh" content="0; url=./HRProprietary/HRConvert2"></head></html>
+<!DOCTYPE html>
+<html>
+<title>HRConvert2 | HRConvert2 Authentication</title>
+<body>
+<div id="outer" align="center"><h1>Configuring HRConvert2 ...</h1>
+
+<div id="inner" style="position:absolute; top:50%; left:50%; height:10em; margin-top:-5em; margin-right:5em;"><strong>Please wait . . .</strong></div>
+</div>
+<script type="text/javascript">
+
+// Set the URL below to the page the user is sent to if their screensize is UNDER the specified number of pixels.
+if (screen.width <= 699) { document.location = "/HRProprietary/HRConvert2/convertCore.php"; }
+// / Set the URL below to the page the user is sent to if their screensize is OVER the specified number of pixels.
+if (screen.width >= 700) { document.location = "/HRProprietary/HRConvert2/convertCore.php"; }
+
+</script>
+
+<meta id="IfNothingHappens" http-equiv="refresh" content="5"; url="/HRProprietary/HRConvert2/convertCore.php" >
+
+</body>
+</html>


### PR DESCRIPTION
* base off latest Ubuntu LTS release image
* use PHP 8.1
* simplify some Dockerfile steps
* pull upstream zelon88/HRConvert2 code from master to always get the latest (seems stable enough)
* add some new values to config.php: $SupportedGuis, $DefaultGui, $AllowUserSelectableGui, $SupportedConversionTypes
* use latest index.html (FIXME: we should really just use the one from upstream source)